### PR TITLE
Show URLs after running setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -264,5 +264,6 @@ A pipeline irá:
 - Aplicar os manifests no cluster Kubernetes
 - Servir a aplicação na porta 8083
 - Servir o Jenkins na porta 32000 via Kubernetes
+- Ao finalizar, o *setup.sh* exibe os links de acesso ao Jenkins e à aplicação Nginx
 
 ✅ Sistema CI/CD totalmente funcional, automatizado com setup.sh

--- a/setup.sh
+++ b/setup.sh
@@ -347,6 +347,7 @@ IP=$(hostname -I | awk '{print $1}')
 #echo -e "\n✅ Jenkins a correr em: http://localhost:8080 ou http://$IP:8080"
 #echo -e "📦 Jenkins Kubernetes exposto via NodePort em: http://$IP:32000 (caso ativado)\n"
 JENKINS_URL="http://$IP:32000"
+NGINX_URL="http://$IP:8083"
 
 echo "⏳ A aguardar que o pod do Jenkins fique em estado Running ..."
 TIMEOUT=180
@@ -423,3 +424,5 @@ java -jar jenkins-cli.jar -s $JENKINS_URL -auth admin:$ADMIN_PWD build hello-ngi
 
 
 echo "🎉 Jenkins configurado com sucesso e pipeline executado!"
+echo "🔗 Jenkins: $JENKINS_URL"
+echo "🔗 Nginx: $NGINX_URL"


### PR DESCRIPTION
## Summary
- display Jenkins and nginx URLs when setup completes
- document that the script shows the access links

## Testing
- `bash -n setup.sh`

------
https://chatgpt.com/codex/tasks/task_e_684856c3ed8883269ac3a07759c25306