### PR TITLE
Fix NodePort issue and add forwarding

### DIFF
--- a/README.md
+++ b/README.md
@@ -262,8 +262,9 @@ A pipeline irá:
 - Buildar a imagem hello-nginx
 - Fazer push para o registry local
 - Aplicar os manifests no cluster Kubernetes
-- Servir a aplicação na porta 8083
+- Servir a aplicação via NodePort 32080 (encaminhada para a porta 8083)
 - Servir o Jenkins na porta 32000 via Kubernetes
 - Ao finalizar, o *setup.sh* exibe os links de acesso ao Jenkins e à aplicação Nginx
+  e cria um redirecionamento local da porta 8083 para o NodePort 32080
 
 ✅ Sistema CI/CD totalmente funcional, automatizado com setup.sh

--- a/k8s/service.yaml
+++ b/k8s/service.yaml
@@ -10,4 +10,4 @@ spec:
   ports:
     - port: 80
       targetPort: 80
-      nodePort: 8083
+      nodePort: 32080

--- a/setup.sh
+++ b/setup.sh
@@ -422,6 +422,14 @@ EOF
 java -jar jenkins-cli.jar -s $JENKINS_URL -auth admin:$ADMIN_PWD create-job hello-nginx-pipeline < hello-nginx.xml
 java -jar jenkins-cli.jar -s $JENKINS_URL -auth admin:$ADMIN_PWD build hello-nginx-pipeline
 
+# Redirecionar a porta externa 8083 para o NodePort 32080, se ainda nao existir
+if ! iptables -t nat -C PREROUTING -p tcp --dport 8083 -j REDIRECT --to-ports 32080 2>/dev/null; then
+  iptables -t nat -A PREROUTING -p tcp --dport 8083 -j REDIRECT --to-ports 32080
+fi
+if ! iptables -t nat -C OUTPUT -p tcp --dport 8083 -j REDIRECT --to-ports 32080 2>/dev/null; then
+  iptables -t nat -A OUTPUT -p tcp --dport 8083 -j REDIRECT --to-ports 32080
+fi
+
 
 echo "🎉 Jenkins configurado com sucesso e pipeline executado!"
 echo "🔗 Jenkins: $JENKINS_URL"


### PR DESCRIPTION
## Summary
- expose hello-nginx via NodePort 32080
- note port 8083 forwarding in README
- redirect port 8083 to NodePort 32080 automatically during setup

## Testing
- `bash -n setup.sh`


------
https://chatgpt.com/codex/tasks/task_e_68485c07ed988326a7147891635671a7