### PR TITLE
Fix registry address for Jenkins pipeline

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -4,7 +4,7 @@ pipeline {
   environment {
     IMAGE_NAME = "hello-nginx"
     IMAGE_TAG = "latest"
-    REGISTRY = "localhost:5000"
+    REGISTRY = env.REGISTRY_ADDR ?: "localhost:5000"
     K8S_DEPLOYMENT_PATH = "k8s/deployment.yaml"
     K8S_SERVICE_PATH = "k8s/service.yaml"
   }
@@ -81,8 +81,8 @@ pipeline {
           token: \$TOKEN
       EOF
       
-        kubectl --kubeconfig=\$KUBECONFIG apply -f ${K8S_DEPLOYMENT_PATH}
-        kubectl --kubeconfig=\$KUBECONFIG apply -f ${K8S_SERVICE_PATH}
+          sed "s|localhost:5000|${REGISTRY}|g" ${K8S_DEPLOYMENT_PATH} | kubectl --kubeconfig=\$KUBECONFIG apply -f -
+          sed "s|localhost:5000|${REGISTRY}|g" ${K8S_SERVICE_PATH} | kubectl --kubeconfig=\$KUBECONFIG apply -f -
       """
       }
     }

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ pipeline {
   environment {
     IMAGE_NAME = "hello-nginx"
     IMAGE_TAG = "latest"
-    REGISTRY = "localhost:5000"
+    REGISTRY = env.REGISTRY_ADDR ?: "localhost:5000"
     K8S_DEPLOYMENT_PATH = "k8s/deployment.yaml"
     K8S_SERVICE_PATH = "k8s/service.yaml"
   }

--- a/k8s/deploy-jenkins.yaml
+++ b/k8s/deploy-jenkins.yaml
@@ -18,6 +18,9 @@ spec:
         - name: jenkins
           image: jenkins-autocontido:latest
           imagePullPolicy: Never
+          env:
+            - name: REGISTRY_ADDR
+              value: "localhost:5000"
           ports:
             - containerPort: 8080
             - containerPort: 50000

--- a/setup.sh
+++ b/setup.sh
@@ -281,6 +281,7 @@ echo "✅ [7/8] Aplicar deployment e service Kubernetes..."
 
 REGISTRY_IP=$(hostname -I | awk '{print $1}')
 sed -i "s|image: jenkins-autocontido:latest|image: ${REGISTRY_IP}:5000/jenkins-autocontido:latest|" k8s/deploy-jenkins.yaml
+sed -i "s|value: \"localhost:5000\"|value: \"${REGISTRY_IP}:5000\"|" k8s/deploy-jenkins.yaml
 
 echo "🔍 A verificar se todos os workers têm a imagem jenkins-autocontido localmente..."
 


### PR DESCRIPTION
## Summary
- expose `REGISTRY_ADDR` env var in the Jenkins deployment
- use this env var in the pipeline and replace the registry host in manifests
- ensure `setup.sh` patches `deploy-jenkins.yaml` with the correct registry IP

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_68486da7cb748326a2299c7f52637251