### PR TITLE
Start Docker daemon in Jenkins if unavailable

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -35,6 +35,19 @@ pipeline {
       }
     }
 
+    stage('Verificar Docker') {
+      steps {
+        sh '''
+          if ! docker info > /dev/null 2>&1; then
+            echo "Docker daemon não acessível, iniciando dockerd em background..."
+            dockerd > /tmp/dockerd.log 2>&1 &
+            sleep 20
+            docker info
+          fi
+        '''
+      }
+    }
+
     stage('Iniciar Registry Local') {
       steps {
         sh '''


### PR DESCRIPTION
## Summary
- ensure the Jenkins pipeline can build Docker images even when no Docker daemon is available by launching `dockerd` inside the Jenkins container

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6849a34010e8832689862cadae0b0669