### PR TITLE
Add container securityContext to Jenkins manifest

### DIFF
--- a/k8s/deploy-jenkins.yaml
+++ b/k8s/deploy-jenkins.yaml
@@ -18,6 +18,8 @@ spec:
         - name: jenkins
           image: jenkins-autocontido:latest
           imagePullPolicy: Never
+          securityContext:
+            privileged: true
           env:
             - name: REGISTRY_ADDR
               value: "localhost:5000"


### PR DESCRIPTION
## Summary
- allow Jenkins container to run in privileged mode by adding securityContext

## Testing
- `yamllint k8s/deploy-jenkins.yaml`
- `./kubectl apply -f k8s/deploy-jenkins.yaml --dry-run=client --validate=false` *(fails: connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_6849a55784d0832693dbdccfdd1cfa7a